### PR TITLE
fix: avoid url_for in custom Jinja templates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
       href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@1,87.5,700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="{{ url_for('static', filename='kids.css', v='birthday-mode-1') }}" />
+    <link rel="stylesheet" href="/static/kids.css?v=birthday-mode-1" />
   </head>
 
   <body class="bg-gray-100 dark:bg-gray-900" style="margin-bottom: 200px">
@@ -219,6 +219,6 @@
     </section>
 
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
-    <script src="{{ url_for('static', filename='kids.js', v='birthday-mode-1') }}"></script>
+    <script src="/static/kids.js?v=birthday-mode-1"></script>
   </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -21,7 +21,7 @@
       rel="stylesheet"
     />
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='kids.css', v='birthday-mode-1') }}" />
+    <link rel="stylesheet" href="/static/kids.css?v=birthday-mode-1" />
   </head>
 
   <body class="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center px-4">


### PR DESCRIPTION
Fixes the runtime 500 introduced by PR #50.

The app renders templates through a custom Jinja environment (`template.render(...)`), so Flask's `url_for` is not available in template globals. Vercel runtime logs show `jinja2.exceptions.UndefinedError: 'url_for' is undefined` on `/login`.

This keeps cache busting but uses explicit static URLs:
- `/static/kids.css?v=birthday-mode-1`
- `/static/kids.js?v=birthday-mode-1`

Applies to both login and main page. No visual or birthday logic changes.