### PR TITLE
feat: birthday card flip and metallic gold reveal

### DIFF
--- a/static/kids.css
+++ b/static/kids.css
@@ -1,58 +1,22 @@
 /* Tema según el sistema */
 @media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
-
-  body {
-    background-color: #171717 !important;
-  }
-
-  body > section .text-gray-700 {
-    color: #d4d4d8;
-  }
-
-  /* Chevron del desplegable de clanes */
-  .relative.w-30 svg path {
-    stroke: #d4d4d8;
-  }
-
-  /* Select: texto legible sobre fondo oscuro */
-  #clanes {
-    color: #f4f4f5;
-  }
-
-  /* Tarjetas: superficie oscura, texto y track de progreso ajustados */
+  html { color-scheme: dark; }
+  body { background-color: #171717 !important; }
+  body > section .text-gray-700 { color: #d4d4d8; }
+  .relative.w-30 svg path { stroke: #d4d4d8; }
+  #clanes { color: #f4f4f5; }
   .kid {
     background-color: #262626 !important;
     border: 1px solid rgb(255 255 255 / 0.14);
-    box-shadow:
-      0 4px 6px -1px rgb(0 0 0 / 0.35),
-      0 2px 4px -2px rgb(0 0 0 / 0.3);
+    box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.35), 0 2px 4px -2px rgb(0 0 0 / 0.3);
   }
-
-  .kid .image-container {
-    box-shadow: 0 0 0 1px rgb(255 255 255 / 0.12);
-  }
-
-  .kid .card-title {
-    color: #fafafa;
-  }
-
-  .kid .text-gray-600 {
-    color: #a3a3a3 !important;
-  }
-
-  .kid .bg-gray-200 {
-    background-color: #404040 !important;
-  }
+  .kid .image-container { box-shadow: 0 0 0 1px rgb(255 255 255 / 0.12); }
+  .kid .card-title { color: #fafafa; }
+  .kid .text-gray-600 { color: #a3a3a3 !important; }
+  .kid .bg-gray-200 { background-color: #404040 !important; }
 }
 
-.header {
-  text-align: center;
-  position: relative;
-  padding: 20px 0;
-}
+.header { text-align: center; position: relative; padding: 20px 0; }
 
 .progress-rojo-intenso { background-color: rgb(255, 0, 0) !important; }
 .progress-rojo-anaranjado { background-color: rgb(255, 64, 0) !important; }
@@ -75,7 +39,6 @@
 .progress-violeta { background-color: rgb(128, 0, 255) !important; }
 .progress-purpura { background-color: rgb(191, 0, 255) !important; }
 
-/* Clase para la barra de progreso dorada con efecto de brillo */
 .progress-gold {
   background-color: #ffd700;
   height: 20px;
@@ -91,153 +54,85 @@
   left: -50%;
   width: 50%;
   height: 100%;
-  background: linear-gradient(
-    90deg,
-    rgba(255, 255, 255, 0) 0%,
-    rgba(255, 255, 255, 0.4) 50%,
-    rgba(255, 255, 255, 0) 100%
-  );
+  background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.4) 50%, rgba(255,255,255,0) 100%);
   animation: shine 3s infinite;
 }
 
-@keyframes shine {
-  0% { left: -50%; }
-  100% { left: 100%; }
-}
-
-@keyframes stripesAnimation {
-  0% { background-position: 100% 0; }
-  100% { background-position: 0 0; }
-}
+@keyframes shine { from { left: -50%; } to { left: 100%; } }
+@keyframes stripesAnimation { from { background-position: 100% 0; } to { background-position: 0 0; } }
 
 .striped-progress-bar {
-  background-image: linear-gradient(
-    45deg,
-    rgba(255, 255, 255, 0.15) 25%,
-    transparent 25%,
-    transparent 50%,
-    rgba(255, 255, 255, 0.15) 50%,
-    rgba(255, 255, 255, 0.15) 75%,
-    transparent 75%,
-    transparent
-  );
+  background-image: linear-gradient(45deg, rgba(255,255,255,.15) 25%, transparent 25%, transparent 50%, rgba(255,255,255,.15) 50%, rgba(255,255,255,.15) 75%, transparent 75%, transparent);
   background-size: 20px 20px;
   animation: stripesAnimation 10s linear infinite;
 }
 
-/* Birthday mode: el dorado de la barra se expande hasta ocupar la tarjeta. */
+/* Birthday mode: la barra al 100% presenta la tarjeta como un cromo dorado. */
 .birthday-card {
   position: relative;
   isolation: isolate;
-  overflow: hidden;
-  transition: transform 260ms ease, box-shadow 500ms ease;
+  transform-style: preserve-3d;
+  will-change: transform;
 }
 
-.birthday-card::before {
-  content: "";
-  position: absolute;
-  z-index: -1;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 22px;
-  opacity: 0;
-  border-radius: inherit;
-  background:
-    radial-gradient(circle at 22% 15%, rgba(255, 255, 255, 0.72), transparent 24%),
-    linear-gradient(135deg, #fff2a8 0%, #ffd700 32%, #e7a900 68%, #fff0a0 100%);
-  transform-origin: bottom center;
+.birthday-card.birthday-flipping {
+  animation: birthday-card-flip 1.05s cubic-bezier(.22,.72,.25,1) both;
 }
 
-.birthday-card.birthday-celebrating::before {
-  opacity: 1;
-  animation: birthday-gold-fill 1.15s cubic-bezier(0.2, 0.75, 0.25, 1) 0.35s forwards;
-}
-
-.birthday-card.birthday-celebrating {
-  animation: birthday-settle 1.55s ease-out both;
-}
-
+.birthday-card.birthday-gold,
 .birthday-card.birthday-settled {
-  background-color: transparent !important;
-  border-color: rgba(151, 104, 0, 0.34);
-  box-shadow:
-    0 12px 28px -14px rgba(116, 77, 0, 0.62),
-    0 4px 10px -5px rgba(116, 77, 0, 0.38);
+  background-color: #ffd700 !important;
+  background-image:
+    radial-gradient(circle at 18% 12%, rgba(255,255,255,.92) 0, rgba(255,255,255,.38) 12%, transparent 26%),
+    linear-gradient(118deg,
+      #9f6a00 0%,
+      #dca900 10%,
+      #fff0a3 22%,
+      #ffd700 34%,
+      #b77900 48%,
+      #ffe56a 62%,
+      #c58c00 76%,
+      #fff1a8 90%,
+      #d5a000 100%) !important;
+  border-color: rgba(112, 74, 0, .48) !important;
+  box-shadow: 0 14px 32px -14px rgba(101,65,0,.72), 0 5px 12px -5px rgba(91,58,0,.48);
 }
 
-.birthday-card.birthday-settled::before {
-  opacity: 1;
-  height: 100%;
-}
-
+.birthday-card.birthday-gold .card-title,
+.birthday-card.birthday-gold .text-gray-600,
+.birthday-card.birthday-gold .text-gray-500,
 .birthday-card.birthday-settled .card-title,
 .birthday-card.birthday-settled .text-gray-600,
 .birthday-card.birthday-settled .text-gray-500 {
-  color: #3f2b00 !important;
+  color: #302000 !important;
 }
 
-.birthday-card.birthday-settled .bg-gray-200 {
-  background-color: rgba(255, 255, 255, 0.42) !important;
-}
-
+.birthday-card.birthday-gold .image-container,
 .birthday-card.birthday-settled .image-container {
-  box-shadow:
-    0 0 0 1px rgba(105, 72, 0, 0.24),
-    0 7px 20px -10px rgba(70, 45, 0, 0.65);
+  box-shadow: 0 0 0 1px rgba(83,55,0,.34), 0 8px 22px -10px rgba(57,36,0,.72);
 }
 
-@keyframes birthday-gold-fill {
-  0% {
-    height: 22px;
-    opacity: 0.94;
-  }
-  100% {
-    height: 100%;
-    opacity: 1;
-  }
-}
+/* Al terminar la presentación la barra ya no aporta información. */
+.birthday-card.birthday-settled > .text-center.mt-4 { display: none; }
 
-@keyframes birthday-settle {
-  0%, 30% { transform: scale(1); }
-  62% { transform: scale(1.02); }
-  100% { transform: scale(1); }
+@keyframes birthday-card-flip {
+  0% { transform: perspective(1200px) rotateY(0deg) scale(1); }
+  42% { transform: perspective(1200px) rotateY(150deg) scale(1.015); }
+  58% { transform: perspective(1200px) rotateY(210deg) scale(1.015); }
+  100% { transform: perspective(1200px) rotateY(360deg) scale(1); }
 }
 
 @media (prefers-reduced-motion: reduce) {
   .birthday-card,
-  .birthday-card::before,
-  .birthday-card.birthday-celebrating,
-  .birthday-card.birthday-celebrating::before {
-    animation: none !important;
-    transition: none !important;
-  }
-
-  .birthday-card::before {
-    height: 100%;
-    opacity: 1;
-  }
-
+  .birthday-card.birthday-flipping { animation: none !important; transition: none !important; transform: none !important; }
+  .birthday-card.birthday-settled > .text-center.mt-4 { display: none; }
   .progress-gold::after,
-  .striped-progress-bar {
-    animation: none !important;
-  }
+  .striped-progress-bar { animation: none !important; }
 }
 
 .image-container { position: relative; }
-
-.video {
-  display: none;
-  object-fit: cover;
-}
-
-.image-container img {
-  display: block;
-  width: 100%;
-  height: auto;
-  border-radius: inherit;
-  object-fit: cover;
-}
+.video { display: none; object-fit: cover; }
+.image-container img { display: block; width: 100%; height: auto; border-radius: inherit; object-fit: cover; }
 
 .archivo-dorsal {
   font-family: "Archivo", sans-serif;
@@ -254,19 +149,10 @@
   color: white;
   font-size: 2.5em;
   font-weight: bold;
-  text-shadow:
-    -2px -2px 0 #000,
-    2px -2px 0 #000,
-    -2px 2px 0 #000,
-    2px 2px 0 #000;
+  text-shadow: -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000;
 }
 
-.festivo {
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
+.festivo { -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; }
 .g1 { background-image: linear-gradient(45deg, #ff0000, #ff7f00, #ffff00); }
 .g2 { background-image: linear-gradient(45deg, #00ff00, #00ffff, #0000ff); }
 .g3 { background-image: linear-gradient(45deg, #8e2de2, #ff0080, #ff0040); }

--- a/static/kids.js
+++ b/static/kids.js
@@ -13,20 +13,22 @@ let indiceGradiente = 0;
 document.getElementById("Fire").onclick = FireCannon;
 
 function Fire(particleRatio, opts) {
-  confetti(
-    Object.assign({}, defaults, opts, {
-      particleCount: Math.floor(count * particleRatio),
-    }),
-  );
+  confetti(Object.assign({}, defaults, opts, {
+    particleCount: Math.floor(count * particleRatio),
+  }));
 }
 
-function FireCannon() {
+function FireCannon(multiplier) {
+  const previousCount = count;
+  if (typeof multiplier === "number") count = Math.floor(count * multiplier);
+
   Fire(0.25, { spread: 26, startVelocity: 55 });
   Fire(0.2, { spread: 60 });
   Fire(0.35, { spread: 100, decay: 0.91, scalar: 0.4 });
   Fire(0.1, { spread: 120, startVelocity: 25, decay: 0.92, scalar: 1.2 });
   Fire(0.1, { spread: 120, startVelocity: 45 });
 
+  count = previousCount;
   titulo.classList.remove(gradientes[indiceGradiente]);
   let nuevoIndice;
   do {
@@ -37,77 +39,53 @@ function FireCannon() {
   titulo.classList.add(gradientes[indiceGradiente]);
 }
 
-function launchBirthdayConfetti(card) {
-  if (typeof confetti !== "function") return;
-
-  const rect = card.getBoundingClientRect();
-  const x = Math.min(0.95, Math.max(0.05, (rect.left + rect.width / 2) / window.innerWidth));
-  const y = Math.min(0.9, Math.max(0.1, (rect.top + rect.height * 0.45) / window.innerHeight));
-
-  confetti({
-    particleCount: 55,
-    spread: 72,
-    startVelocity: 28,
-    gravity: 0.85,
-    scalar: 0.72,
-    ticks: 130,
-    origin: { x: x, y: y },
-  });
-}
-
 function initBirthdayMode() {
   const cards = document.querySelectorAll('[data-birthday-card="true"]');
   if (!cards.length) return;
 
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 
+  if (reduceMotion) {
+    cards.forEach((card) => card.classList.add("birthday-gold", "birthday-settled"));
+    return;
+  }
+
+  /* La misma celebración del título, una sola vez y algo más abundante. */
+  window.setTimeout(() => FireCannon(1.35), 180);
+
   cards.forEach((card) => {
-    if (reduceMotion) {
-      card.classList.add("birthday-settled");
-      return;
-    }
+    requestAnimationFrame(() => card.classList.add("birthday-flipping"));
 
-    requestAnimationFrame(() => {
-      card.classList.add("birthday-celebrating");
-    });
-
-    window.setTimeout(() => launchBirthdayConfetti(card), 900);
+    /* El cambio a oro ocurre cuando la tarjeta está casi de canto. */
+    window.setTimeout(() => card.classList.add("birthday-gold"), 500);
     window.setTimeout(() => {
-      card.classList.remove("birthday-celebrating");
+      card.classList.remove("birthday-flipping");
       card.classList.add("birthday-settled");
-    }, 1750);
+    }, 1080);
   });
 }
 
 document.addEventListener("DOMContentLoaded", initBirthdayMode);
 
 document.getElementById("filtro").addEventListener("change", function () {
-  if (this.checked) {
-    ordenarDivsDorsal();
-  } else {
-    ordenarDivsFecha();
-  }
+  if (this.checked) ordenarDivsDorsal();
+  else ordenarDivsFecha();
 });
 
 function mostrarVideo(kidid) {
   var divid = kidid + "-div";
   var div = document.getElementById(divid);
-
   var imagen = div.querySelector("img");
   var video = div.querySelector("video");
-
   imagen.style.display = "none";
   video.style.display = "block";
-
   video.setAttribute("playsinline", "");
   video.currentTime = 0;
   video.play();
-
   video.onended = function () {
     video.currentTime = 0;
     video.load();
     video.pause();
-
     imagen.style.display = "block";
     video.style.display = "none";
   };
@@ -116,51 +94,35 @@ function mostrarVideo(kidid) {
 function ordenarDivsDorsal() {
   const container = document.getElementById("contenedor");
   const items = Array.from(container.querySelectorAll(".kid"));
-
   items.sort((a, b) => {
     const numA = parseInt(a.querySelector(".dorsal").textContent.replace("#", ""));
     const numB = parseInt(b.querySelector(".dorsal").textContent.replace("#", ""));
     return numA - numB;
   });
-
   items.forEach((item) => container.appendChild(item));
 }
 
 function ordenarDivsFecha() {
   const container = document.getElementById("contenedor");
   const items = Array.from(container.querySelectorAll(".kid"));
-
   items.sort((a, b) => {
     const fechaA = a.querySelector(".fecha").textContent.trim();
     const fechaB = b.querySelector(".fecha").textContent.trim();
-
-    const dateA = new Date(fechaA);
-    const dateB = new Date(fechaB);
-
-    return dateA - dateB;
+    return new Date(fechaA) - new Date(fechaB);
   });
-
   items.forEach((item) => container.appendChild(item));
 }
 
 const selectorClan = document.getElementById("clanes");
 const contenedor = document.getElementById("contenedor");
-
 selectorClan.addEventListener("change", function () {
   const filtro = this.value;
   const kids = contenedor.getElementsByClassName("kid");
-
   Array.from(kids).forEach((kid) => {
     const spanClan = kid.querySelector(".clan");
-
     if (spanClan) {
       const valorClan = spanClan.textContent.trim();
-
-      if (!filtro || valorClan === filtro) {
-        kid.style.display = "";
-      } else {
-        kid.style.display = "none";
-      }
+      kid.style.display = !filtro || valorClan === filtro ? "" : "none";
     }
   });
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,221 +4,46 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Resaca de Cumples</title>
-    <link
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
-      rel="stylesheet"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,container-queries"></script>
-    <script>
-      tailwind.config = { darkMode: "media" };
-    </script>
+    <script>tailwind.config = { darkMode: "media" };</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@1,87.5,700&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="stylesheet" href="/static/kids.css?v=birthday-mode-1" />
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@1,87.5,700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/static/kids.css?v=birthday-mode-2" />
   </head>
-
   <body class="bg-gray-100 dark:bg-gray-900" style="margin-bottom: 200px">
     {% if uploaded %}
-    <div
-      id="success-banner"
-      class="fixed top-4 left-1/2 transform -translate-x-1/2 bg-green-500 text-white px-6 py-3 rounded-2xl shadow-lg z-50 flex items-center gap-3 transition-opacity duration-500"
-    >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        class="h-5 w-5 flex-shrink-0"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-      >
-        <path
-          fill-rule="evenodd"
-          d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-          clip-rule="evenodd"
-        />
-      </svg>
-      {{ t.success_pre }} <strong class="mx-1">{{ uploaded }}</strong> {{
-      t.success_post }}
+    <div id="success-banner" class="fixed top-4 left-1/2 transform -translate-x-1/2 bg-green-500 text-white px-6 py-3 rounded-2xl shadow-lg z-50 flex items-center gap-3 transition-opacity duration-500">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd" /></svg>
+      {{ t.success_pre }} <strong class="mx-1">{{ uploaded }}</strong> {{ t.success_post }}
     </div>
-    <script>
-      setTimeout(function () {
-        const b = document.getElementById("success-banner");
-        b.style.opacity = "0";
-        setTimeout(() => window.location.replace("/"), 500);
-      }, 3000);
-    </script>
+    <script>setTimeout(function () { const b = document.getElementById("success-banner"); b.style.opacity = "0"; setTimeout(() => window.location.replace("/"), 500); }, 3000);</script>
     {% endif %}
-
     <section class="container mx-auto p-6">
-      <h2
-        class="text-4xl font-bold text-center mb-8 titulo festivo g1"
-        id="Fire"
-        style="user-select: none"
-      >
-        {{ t.page_title }}
-      </h2>
-
+      <h2 class="text-4xl font-bold text-center mb-8 titulo festivo g1" id="Fire" style="user-select: none">{{ t.page_title }}</h2>
       <div class="flex justify-between items-end mb-2">
-        <div class="flex items-center gap-2">
-          <div class="relative w-30" style="margin-bottom: -6px">
-            <span
-              class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-1"
-            >
-              <svg
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 14 8"
-                class="w-3 h-3 text-gray-800 dark:text-white"
-              >
-                <path
-                  stroke="#000000"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="m1 1 5.326 5.7a.909.909 0 0 0 1.348 0L13 1"
-                ></path>
-              </svg>
-            </span>
-
-            <select
-              id="clanes"
-              name="clanes"
-              style="font-weight: bold"
-              class="appearance-none bg-none block w-full bg-transparent border-0 border-b-0 border-default-medium text-sm text-body focus:outline-none focus:ring-0 focus:border-brand peer py-2.5 pl-6 pr-2"
-            >
-              <option value="">{{ t.filter_all }}</option>
-
-              {% for clan in clanes %}
-              <option value="{{ clan.clan }}">{{ clan.clan_name }}</option>
-              {% endfor %}
-            </select>
-          </div>
-        </div>
-
-        <div class="flex items-center gap-4">
-          <span class="text-gray-700 text-sm">{{ t.filter_date }}</span>
-          <label
-            class="relative inline-flex items-center cursor-pointer"
-            style="margin-left: -10px; margin-right: -10px"
-          >
-            <input type="checkbox" id="filtro" class="sr-only peer" />
-            <div
-              class="w-14 h-7 bg-red-500 rounded-full peer peer-checked:bg-blue-500 transition-all"
-            ></div>
-            <div
-              class="absolute left-1 top-1 w-5 h-5 bg-white rounded-full shadow-md peer-checked:translate-x-7 transition-all"
-            ></div>
-          </label>
-          <span class="text-gray-700 text-sm">{{ t.filter_number }}</span>
-        </div>
+        <div class="flex items-center gap-2"><div class="relative w-30" style="margin-bottom: -6px"><span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-1"><svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 8" class="w-3 h-3 text-gray-800 dark:text-white"><path stroke="#000000" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 5.326 5.7a.909.909 0 0 0 1.348 0L13 1"></path></svg></span>
+          <select id="clanes" name="clanes" style="font-weight: bold" class="appearance-none bg-none block w-full bg-transparent border-0 border-b-0 border-default-medium text-sm text-body focus:outline-none focus:ring-0 focus:border-brand peer py-2.5 pl-6 pr-2"><option value="">{{ t.filter_all }}</option>{% for clan in clanes %}<option value="{{ clan.clan }}">{{ clan.clan_name }}</option>{% endfor %}</select>
+        </div></div>
+        <div class="flex items-center gap-4"><span class="text-gray-700 text-sm">{{ t.filter_date }}</span><label class="relative inline-flex items-center cursor-pointer" style="margin-left: -10px; margin-right: -10px"><input type="checkbox" id="filtro" class="sr-only peer" /><div class="w-14 h-7 bg-red-500 rounded-full peer peer-checked:bg-blue-500 transition-all"></div><div class="absolute left-1 top-1 w-5 h-5 bg-white rounded-full shadow-md peer-checked:translate-x-7 transition-all"></div></label><span class="text-gray-700 text-sm">{{ t.filter_number }}</span></div>
       </div>
-
-      <div
-        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6"
-        id="contenedor"
-      >
+      <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6" id="contenedor">
         {% for kid in kids %}
-        <div
-          class="bg-white p-6 rounded-lg shadow-md kid{% if kid.cumple_today %} birthday-card{% endif %}"
-          {% if kid.cumple_today %}data-birthday-card="true"{% endif %}
-        >
-          <div
-            class="image-container rounded-xl"
-            id="{{kid.nombre | lower}}-div"
-          >
-            {% if kid.video %}
-            <img
-              class="object-cover w-full rounded-xl aspect-square card-img-top mx-auto mb-4"
-              src="{{ kid.image }}"
-              onclick="mostrarVideo('{{kid.nombre | lower}}')"
-              alt=""
-            />
-            <span class="dorsal archivo-dorsal">#{{ kid.dorsal }}</span>
-            <video
-              class="object-cover w-full rounded-xl aspect-square card-img-top mx-auto mb-4 video"
-              playsinline
-            >
-              <source
-                src="static/videos/{{ kid.normalized }}.mp4"
-                type="video/mp4"
-              />
-              {{ t.video_unsupported }}
-            </video>
-            {% else %}
-            <img
-              class="object-cover w-full rounded-xl aspect-square card-img-top mx-auto mb-4"
-              src="{{ kid.image }}"
-              alt=""
-            />
-            <span class="dorsal archivo-dorsal">#{{ kid.dorsal }}</span>
-            {% endif %}
+        <div class="bg-white p-6 rounded-lg shadow-md kid{% if kid.cumple_today %} birthday-card{% endif %}" {% if kid.cumple_today %}data-birthday-card="true"{% endif %}>
+          <div class="image-container rounded-xl" id="{{kid.nombre | lower}}-div">
+            {% if kid.video %}<img class="object-cover w-full rounded-xl aspect-square card-img-top mx-auto mb-4" src="{{ kid.image }}" onclick="mostrarVideo('{{kid.nombre | lower}}')" alt="" /><span class="dorsal archivo-dorsal">#{{ kid.dorsal }}</span><video class="object-cover w-full rounded-xl aspect-square card-img-top mx-auto mb-4 video" playsinline><source src="static/videos/{{ kid.normalized }}.mp4" type="video/mp4" />{{ t.video_unsupported }}</video>
+            {% else %}<img class="object-cover w-full rounded-xl aspect-square card-img-top mx-auto mb-4" src="{{ kid.image }}" alt="" /><span class="dorsal archivo-dorsal">#{{ kid.dorsal }}</span>{% endif %}
           </div>
-
-          <div class="flex" style="justify-content: center">
-            <h3 class="text-xl font-semibold text-center card-title">
-              {{ kid.display_name(t) }}
-            </h3>
-            {% if not kid.embarazo and not kid.cumple_today %}
-            <span class="text-gray-600 text-xl" style="margin-left: 4px"
-              >({{ kid.edad-1 }})</span
-            >
-            {% endif %}
-          </div>
-
-          <p class="text-gray-600 text-center card-subtitle">
-            {{ kid.label(t) }}
-          </p>
-          <span hidden class="fecha">{{ kid.cumple_date }}</span>
-          <span hidden class="clan">{{ kid.clan }}</span>
-          <div class="text-center mt-4">
-            <div
-              class="w-full max-w-xl bg-gray-200 rounded-full h-5 overflow-hidden"
-            >
-              <div
-                class="auxbar {{ kid.color }}"
-                style="width: {{ kid.progreso }}%;"
-              ></div>
-            </div>
-          </div>
-          {% set countdown = kid.countdown(t) %}
-          {% if countdown %}
-          <p class="text-gray-500 text-center text-sm mt-1">
-            {{ countdown }}
-          </p>
-          {% endif %}
-        </div>
-        {% endfor %}
+          <div class="flex" style="justify-content: center"><h3 class="text-xl font-semibold text-center card-title">{{ kid.display_name(t) }}</h3>{% if not kid.embarazo and not kid.cumple_today %}<span class="text-gray-600 text-xl" style="margin-left: 4px">({{ kid.edad-1 }})</span>{% endif %}</div>
+          <p class="text-gray-600 text-center card-subtitle">{{ kid.label(t) }}</p><span hidden class="fecha">{{ kid.cumple_date }}</span><span hidden class="clan">{{ kid.clan }}</span>
+          <div class="text-center mt-4"><div class="w-full max-w-xl bg-gray-200 rounded-full h-5 overflow-hidden"><div class="auxbar {{ kid.color }}" style="width: {{ kid.progreso }}%;"></div></div></div>
+          {% set countdown = kid.countdown(t) %}{% if countdown %}<p class="text-gray-500 text-center text-sm mt-1">{{ countdown }}</p>{% endif %}
+        </div>{% endfor %}
       </div>
-
-      <div
-        class="flex justify-between items-center mb-2"
-        style="margin-top: 10px"
-      >
-        <div class="flex items-center gap-1 text-xs">
-          <a
-            href="/set_language/es"
-            class="{{ 'font-semibold text-gray-800 dark:text-gray-100' if lang == 'es' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}"
-            >ES</a
-          >
-          <span class="text-gray-300 dark:text-gray-600">|</span>
-          <a
-            href="/set_language/ca"
-            class="{{ 'font-semibold text-gray-800 dark:text-gray-100' if lang == 'ca' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}"
-            >CA</a
-          >
-        </div>
-        <a
-          href="/upload"
-          class="text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline"
-          >{{ t.upload_link }}</a
-        >
-      </div>
+      <div class="flex justify-between items-center mb-2" style="margin-top: 10px"><div class="flex items-center gap-1 text-xs"><a href="/set_language/es" class="{{ 'font-semibold text-gray-800 dark:text-gray-100' if lang == 'es' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">ES</a><span class="text-gray-300 dark:text-gray-600">|</span><a href="/set_language/ca" class="{{ 'font-semibold text-gray-800 dark:text-gray-100' if lang == 'ca' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">CA</a></div><a href="/upload" class="text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline">{{ t.upload_link }}</a></div>
     </section>
-
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
-    <script src="/static/kids.js?v=birthday-mode-1"></script>
+    <script src="/static/kids.js?v=birthday-mode-2"></script>
   </body>
 </html>


### PR DESCRIPTION
Refines Birthday Mode based on visual review:

- Removes the card-local confetti burst.
- Reuses the existing full-page title celebration automatically once on Birthday Mode, with 35% more particles.
- Birthday card starts with its completed gold progress bar visible.
- Card performs a short 360° Y-axis flip, like presenting a collectible card.
- Gold appearance switches while the card is nearly edge-on, avoiding a fill animation.
- Final card uses a multi-tone metallic gold gradient rather than a flat yellow/gold.
- Progress bar disappears after the reveal.
- Keeps `prefers-reduced-motion` support (instant gold state, no flip/confetti).
- Bumps birthday static asset cache to `birthday-mode-2`.