### PR TITLE
fix: launch birthday confetti after card flip

### DIFF
--- a/static/kids.js
+++ b/static/kids.js
@@ -19,7 +19,6 @@ function initBirthdayMode() {
   if (!cards.length) return;
   const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   if (reduceMotion) { cards.forEach((card) => card.classList.add("birthday-gold", "birthday-settled")); return; }
-  window.setTimeout(() => FireCannon(1.35), 180);
   cards.forEach((card) => {
     /* Primero dejamos ver claramente la barra completa y su brillo. */
     window.setTimeout(() => card.classList.add("birthday-flipping"), 700);
@@ -27,6 +26,8 @@ function initBirthdayMode() {
     window.setTimeout(() => card.classList.add("birthday-gold"), 1200);
     window.setTimeout(() => { card.classList.remove("birthday-flipping"); card.classList.add("birthday-settled"); }, 1720);
   });
+  /* La celebración remata la presentación cuando la tarjeta ya ha terminado el giro. */
+  window.setTimeout(() => FireCannon(1.35), 1740);
 }
 document.addEventListener("DOMContentLoaded", initBirthdayMode);
 document.getElementById("filtro").addEventListener("change", function () { if (this.checked) ordenarDivsDorsal(); else ordenarDivsFecha(); });


### PR DESCRIPTION
Moves the automatic Birthday Mode celebration to the end of the card reveal.

Sequence is now:
1. Completed gold bar is visible.
2. Card performs the 360° reveal.
3. Card settles in gold and the progress bar disappears.
4. Full-page celebration fires immediately after the flip finishes.

No visual or timing changes to the flip itself.