### PR TITLE
feat: make Family Progress installable as a PWA

### DIFF
--- a/static/app-icon.svg
+++ b/static/app-icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="112" fill="#ffd700"/>
+  <rect x="62" y="62" width="388" height="388" rx="82" fill="#ffe650" stroke="#7e5600" stroke-width="12"/>
+  <text x="256" y="285" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="142" font-weight="700" fill="#3e2b00">100</text>
+  <rect x="128" y="348" width="256" height="30" rx="15" fill="#ffd700" stroke="#7e5600" stroke-width="6"/>
+</svg>

--- a/static/manifest.webmanifest
+++ b/static/manifest.webmanifest
@@ -1,0 +1,18 @@
+{
+  "name": "Resaca de Cumples",
+  "short_name": "Cumples",
+  "description": "Progreso de cumpleaños familiar",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f3f4f6",
+  "theme_color": "#ffd700",
+  "icons": [
+    {
+      "src": "/static/app-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,15 +2,22 @@
 <html lang="{{ lang }}">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Resaca de Cumples</title>
+    <meta name="theme-color" content="#ffd700" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Cumples" />
+    <link rel="manifest" href="/static/manifest.webmanifest" />
+    <link rel="icon" href="/static/app-icon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/static/app-icon.svg" />
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,container-queries"></script>
     <script>tailwind.config = { darkMode: "media" };</script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@1,87.5,700&display=swap" rel="stylesheet" />
-    <link rel="stylesheet" href="/static/kids.css?v=birthday-mode-3" />
+    <link rel="stylesheet" href="/static/kids.css" />
   </head>
   <body class="bg-gray-100 dark:bg-gray-900" style="margin-bottom: 200px">
     {% if uploaded %}
@@ -44,6 +51,6 @@
       <div class="flex justify-between items-center mb-2" style="margin-top: 10px"><div class="flex items-center gap-1 text-xs"><a href="/set_language/es" class="{{ 'font-semibold text-gray-800 dark:text-gray-100' if lang == 'es' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">ES</a><span class="text-gray-300 dark:text-gray-600">|</span><a href="/set_language/ca" class="{{ 'font-semibold text-gray-800 dark:text-gray-100' if lang == 'ca' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">CA</a></div><a href="/upload" class="text-sm text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline">{{ t.upload_link }}</a></div>
     </section>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
-    <script src="/static/kids.js?v=birthday-mode-3"></script>
+    <script src="/static/kids.js"></script>
   </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -2,68 +2,36 @@
 <html lang="{{ lang }}">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>{{ t.login_tab_title }}</title>
-
-    <link
-      href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css"
-      rel="stylesheet"
-    />
+    <meta name="theme-color" content="#ffd700" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-title" content="Cumples" />
+    <link rel="manifest" href="/static/manifest.webmanifest" />
+    <link rel="icon" href="/static/app-icon.svg" type="image/svg+xml" />
+    <link rel="apple-touch-icon" href="/static/app-icon.svg" />
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,container-queries"></script>
     <script>tailwind.config = { darkMode: 'media' }</script>
-
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-
-    <link
-      href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@1,87.5,700&display=swap"
-      rel="stylesheet"
-    />
-
-    <link rel="stylesheet" href="/static/kids.css?v=birthday-mode-1" />
+    <link href="https://fonts.googleapis.com/css2?family=Archivo:ital,wdth,wght@1,87.5,700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/static/kids.css" />
   </head>
-
   <body class="min-h-screen bg-gray-100 dark:bg-gray-900 flex items-center justify-center px-4">
-
     <div class="w-full max-w-sm bg-white dark:bg-gray-800 rounded-3xl shadow-xl p-6 sm:p-8 border border-transparent dark:border-gray-700">
-      <h1 class="text-2xl sm:text-3xl font-bold text-center mb-2 text-gray-800 dark:text-gray-100">
-        {{ t.login_title }}
-      </h1>
-
-      <p class="text-center text-gray-600 dark:text-gray-300 mb-6 text-sm sm:text-base">
-        {{ t.login_subtitle }}
-      </p>
-
-      {% if error %}
-      <div class="bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-200 p-3 rounded-xl mb-4 text-sm">
-        {{ error }}
-      </div>
-      {% endif %}
-
+      <h1 class="text-2xl sm:text-3xl font-bold text-center mb-2 text-gray-800 dark:text-gray-100">{{ t.login_title }}</h1>
+      <p class="text-center text-gray-600 dark:text-gray-300 mb-6 text-sm sm:text-base">{{ t.login_subtitle }}</p>
+      {% if error %}<div class="bg-red-100 dark:bg-red-950 text-red-700 dark:text-red-200 p-3 rounded-xl mb-4 text-sm">{{ error }}</div>{% endif %}
       <form method="POST" class="space-y-4">
-        <input
-          type="password"
-          name="password"
-          placeholder="{{ t.login_placeholder }}"
-          required
-          class="w-full rounded-xl border border-gray-300 dark:border-gray-600 px-4 py-3 text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-700 placeholder-gray-400 dark:placeholder-gray-400 text-base focus:border-gray-500 dark:focus:border-gray-400 focus:ring-gray-500 dark:focus:ring-gray-400"
-        />
-
-        <button
-          type="submit"
-          class="w-full bg-black dark:bg-gray-100 text-white dark:text-gray-900 py-3 rounded-xl text-base font-medium hover:opacity-90 transition"
-        >
-          {{ t.login_button }}
-        </button>
+        <input type="password" name="password" placeholder="{{ t.login_placeholder }}" required class="w-full rounded-xl border border-gray-300 dark:border-gray-600 px-4 py-3 text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-700 placeholder-gray-400 dark:placeholder-gray-400 text-base focus:border-gray-500 dark:focus:border-gray-400 focus:ring-gray-500 dark:focus:ring-gray-400" />
+        <button type="submit" class="w-full bg-black dark:bg-gray-100 text-white dark:text-gray-900 py-3 rounded-xl text-base font-medium hover:opacity-90 transition">{{ t.login_button }}</button>
       </form>
-
       <div class="flex justify-center items-center gap-1 text-xs mt-5">
-        <a href="/set_language/es"
-          class="{{ 'font-semibold text-gray-700 dark:text-gray-200' if lang == 'es' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">ES</a>
+        <a href="/set_language/es" class="{{ 'font-semibold text-gray-700 dark:text-gray-200' if lang == 'es' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">ES</a>
         <span class="text-gray-300 dark:text-gray-600">|</span>
-        <a href="/set_language/ca"
-          class="{{ 'font-semibold text-gray-700 dark:text-gray-200' if lang == 'ca' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">CA</a>
+        <a href="/set_language/ca" class="{{ 'font-semibold text-gray-700 dark:text-gray-200' if lang == 'ca' else 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300' }}">CA</a>
       </div>
     </div>
   </body>

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,17 @@
       "use": "@vercel/python"
     }
   ],
+  "headers": [
+    {
+      "source": "/static/(kids\\.css|kids\\.js|manifest\\.webmanifest)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, must-revalidate"
+        }
+      ]
+    }
+  ],
   "routes": [
     {
       "src": "/(.*)",

--- a/vercel.json
+++ b/vercel.json
@@ -8,13 +8,16 @@
   ],
   "headers": [
     {
-      "source": "/static/(kids\\.css|kids\\.js|manifest\\.webmanifest)",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "no-cache, must-revalidate"
-        }
-      ]
+      "source": "/static/kids.css",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache, must-revalidate" }]
+    },
+    {
+      "source": "/static/kids.js",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache, must-revalidate" }]
+    },
+    {
+      "source": "/static/manifest.webmanifest",
+      "headers": [{ "key": "Cache-Control", "value": "no-cache, must-revalidate" }]
     }
   ],
   "routes": [


### PR DESCRIPTION
Adds a lightweight PWA setup focused on iPhone/Home Screen use without introducing a service worker or offline cache.

### PWA/install experience
- Adds `manifest.webmanifest` with standalone display mode, app name, theme/background colors and icon.
- Adds iOS standalone metadata to the main app and login page.
- Adds an app icon and manifest/favicon references.
- Uses `viewport-fit=cover` for installed/full-screen presentation.

### Fresh deploy behavior
- Removes the manually maintained `?v=birthday-mode-N` asset versions.
- Configures `kids.css`, `kids.js` and the manifest with `Cache-Control: no-cache, must-revalidate` on Vercel.
- This deliberately does **not** add a service worker, avoiding a second persistent cache layer. Installed Home Screen instances should revalidate the app's CSS/JS instead of remaining stuck on an old manually-versioned asset.

No application/business logic changes.